### PR TITLE
Fix regression re report-size-deltas after updating actions/upload-artifact.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -52,6 +52,7 @@ jobs:
               - examples/OTA_Arduino_Server
               - examples/OTA_GitHub_Server
               - examples/LOLIN_32_Blink
+            artifact-name-suffix: esp32-esp32-esp32
           - board:
               type: arduino_esp32
             platforms: |
@@ -62,6 +63,7 @@ jobs:
               - examples/OTA_Arduino_Server
               - examples/OTA_GitHub_Server
               - examples/NANO_ESP32_Blink
+            artifact-name-suffix: arduino-esp32-arduino_esp32
 
     steps:
       - name: Checkout
@@ -89,6 +91,6 @@ jobs:
       - name: Save memory usage change report as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: sketches-report-${{ matrix.board.artifact-name-suffix }}
           if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Comment size deltas reports to PRs
         uses: arduino/report-size-deltas@v1
         with:
-          # The name of the workflow artifact created by the "Compile Examples" workflow
-          sketches-reports-source: sketches-reports
+          # Regex matching the names of the workflow artifacts created by the "Compile Examples" workflow
+          sketches-reports-source: ^sketches-report-.+


### PR DESCRIPTION
For more information see https://github.com/arduino/report-size-deltas/blob/main/docs/FAQ.md#size-deltas-report-workflow-triggered-by-schedule-event .