### PR TITLE
Standardize license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,17 +1,3 @@
-This file includes licensing information for ArduinoIoTCloud
-
-Copyright (c) 2019 ARDUINO SA (www.arduino.cc)
-
-The software is released under the GNU General Public License, which covers the main body
-of the ArduinoIoTCloud code. The terms of this license can be found at:
-https://www.gnu.org/licenses/gpl-3.0.en.html
-
-You can be released from the requirements of the above licenses by purchasing
-a commercial license. Buying such a license is mandatory if you want to modify or
-otherwise use the software for commercial activities involving the Arduino
-software without disclosing the source code of your own applications. To purchase
-a commercial license, send an email to license@arduino.cc
-
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/README.md
+++ b/README.md
@@ -54,3 +54,9 @@ The library is based on the [Update](https://github.com/espressif/arduino-esp32/
     | `ESP32-­S2-­SOLO` | [ESP32-S2-DevKitC-1](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-s2-devkitc-1.html) |
     |  | NodeMCU-32-S2 |
     | `ESP32-C3`  | [LILYGO mini D1 PLUS](https://github.com/Xinyuan-LilyGO/LilyGo-T-OI-PLUS)|
+
+## :page_with_curl: License
+
+Arduino_ESP32_OTA is licensed under the GNU General Public License v3.0 license.
+
+You can be released from the requirements of the above license by purchasing a commercial license. Buying such a license is mandatory if you want to modify or otherwise use the software for commercial activities involving the Arduino software without disclosing the source code of your own applications. To purchase a commercial license, send an email to license@arduino.cc


### PR DESCRIPTION
Standardization in license documentation is important because, in addition to making it easy for humans to find this vital information, it allows machines to automate the process of license type determination, which is useful both for discovering suitable open source projects as well as checking open source license compliance.

The open source license of this project is already stored in a [standardized location](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository#determining-the-location-of-your-license) in a dedicated license file. However, even though the project is licensed under a standardized open source license, additional text was added to the license file which offers the option to purchase an [exception for proprietary use of the project](https://www.gnu.org/philosophy/selling-exceptions.html). Even though this offer does not have any legal effect on the open source license, the presence of that text made it so that the open license type could not be identified with 100% confidence by machines (e.g., the [**Licensee** Gem](https://github.com/licensee/licensee) which is [used by the GitHub website](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository#detecting-a-license)), which meant identification could only be made by a human carefully evaluating the license text.

Since there is no need to place the exception offer in the license file, it can be moved to the readme, with the license file containing only [the verbatim standardized open source license text](https://choosealicense.com/appendix/). The result is that the project's open source license type can now be automatically identified, without making any change to the licensing.